### PR TITLE
Add pyteomics & pin.

### DIFF
--- a/app.py
+++ b/app.py
@@ -162,7 +162,7 @@ NAVBAR = dbc.Navbar(
         ),
         dbc.Nav(
             [
-                dbc.NavItem(dbc.NavLink("GNPS LCMS Dashboard - Version 2025-03-18", href="/")),
+                dbc.NavItem(dbc.NavLink("GNPS LCMS Dashboard - Version 2025-06-23", href="/")),
                 dbc.NavItem(dbc.NavLink("Documentation", href="https://ccms-ucsd.github.io/GNPSDocumentation/lcms-dashboard/")),
                 dbc.NavItem(dbc.NavLink("GNPS Datasets", href="https://gnps.ucsd.edu/ProteoSAFe/datasets.jsp#%7B%22query%22%3A%7B%7D%2C%22table_sort_history%22%3A%22createdMillis_dsc%22%2C%22title_input%22%3A%22GNPS%22%7D")),
                 dbc.NavItem(id="dataset_files_nav"),

--- a/requirements-conversion.txt
+++ b/requirements-conversion.txt
@@ -13,3 +13,4 @@ psims
 netcdf4
 dask[complete]==2024.1.0
 tqdm
+pyteomics==4.7.5


### PR DESCRIPTION
This PR fixes https://github.com/Wang-Bioinformatics-Lab/GNPS_LCMSDashboard/issues/302, by adding Pyteomics as a requirement to the conversion environment. The version is tested and pinned at 4.7.5.

The dashboard version is bumped to 2025-06-23.